### PR TITLE
[fix] Add `@types/jest` to dev dependdencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "ws": "7.4.2"
   },
   "devDependencies": {
+    "@types/jest": "^26.0.20",
     "@types/node": "14.14.22",
     "@types/ws": "7.4.0",
     "@typescript-eslint/eslint-plugin": "4.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -575,7 +575,7 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.x":
+"@types/jest@26.x", "@types/jest@^26.0.20":
   version "26.0.20"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
   integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==


### PR DESCRIPTION
## `@types/jest` was missing from dev dependencies.

In VS Code language server can't resolve `describe` and `it` as methods. Reason for this behavior was missing types.

## TODO

- [x] Add `@types/jest` to `devDependecies` in `package.json`.
- [x] Update lock file.
